### PR TITLE
missed quotation marks added

### DIFF
--- a/root/etc/e-smith/templates/etc/fail2ban/jail.local/10sogo
+++ b/root/etc/e-smith/templates/etc/fail2ban/jail.local/10sogo
@@ -1,5 +1,5 @@
 {
-return "\n#sogo is not used on this server" unless ( -f /var/log/sogo/sogo.log );
+return "\n#sogo is not used on this server" unless ( -f '/var/log/sogo/sogo.log');
 
 my $SogoAuth_status = $fail2ban{SogoAuth_status} || 'true';
 my $TCPPorts = $httpd{TCPPorts} || '80,443';


### PR DESCRIPTION
I got an error when performing the nethserver-fail2ban-save event due to the lost quotation marks in 10sogo... 