### PR TITLE
Migrate mail addresses for old installations

### DIFF
--- a/root/etc/e-smith/db/configuration/migrate/Fail2BanMail
+++ b/root/etc/e-smith/db/configuration/migrate/Fail2BanMail
@@ -1,0 +1,9 @@
+{
+    #Leave BanAction shorewall to shorewall-nethserver
+    my $custom = $DB->get_prop('fail2ban','CustomDestemail')|| '';
+    my $mail = $DB->get_prop('fail2ban','Mail')|| 'disabled';
+    if ($mail eq 'enabled' && $custom eq '') {
+        $DB->set_prop('fail2ban','CustomDestemail','admin@'.$DomainName);
+    }
+    '';
+}


### PR DESCRIPTION
On old installation, the default notification mail was admin@<mydomain>.
Push the old default inside the CustomDestemail prop if mail notification is
enabled.

Related to PR #20 